### PR TITLE
Make the router regexp based to allow parameters

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "fxos-mvc",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "homepage": "https://github.com/fxos/mvc",
   "license": "MPL",
   "main": "mvc.js",

--- a/dist/mvc.js
+++ b/dist/mvc.js
@@ -1582,14 +1582,19 @@ define(["exports"], function (exports) {
 
     RoutingController.prototype.route = function () {
       var route = window.location.hash.slice(1);
-      var controller = this._controllers[route];
-      if (controller) {
-        if (this.activeController) {
-          this.activeController.teardown();
-        }
+      for (var routeName in this._controllers) {
+        var regexp = new RegExp("^" + routeName + "$");
+        var match = route.match(regexp);
+        var controller = this._controllers[routeName];
+        if (match && controller) {
+          if (this.activeController) {
+            this.activeController.teardown();
+          }
 
-        this.activeController = controller;
-        controller.main();
+          this.activeController = controller;
+          controller.main.apply(controller, match.slice(1));
+          break;
+        }
       }
     };
 

--- a/mvc.js
+++ b/mvc.js
@@ -240,14 +240,19 @@ export class RoutingController extends Controller {
 
   route() {
     var route = window.location.hash.slice(1);
-    var controller = this._controllers[route];
-    if (controller) {
-      if (this.activeController) {
-        this.activeController.teardown();
-      }
+    for (var routeName in this._controllers) {
+      var regexp = new RegExp(`^${routeName}$`);
+      var match = route.match(regexp);
+      var controller = this._controllers[routeName];
+      if (match && controller) {
+        if (this.activeController) {
+          this.activeController.teardown();
+        }
 
-      this.activeController = controller;
-      controller.main();
+        this.activeController = controller;
+        controller.main.apply(controller, match.slice(1));
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
This patch changes the router to allow parameters, e.g.:
```js
export default class MainController extends RoutingController {
  constructor() {
    super({
      'list': new ListController(),
      'play/(.+)': new PlayController()
    });
  }
}
```

Use capturing groups in the regexp of the router name to add parameters: opening `#play/abc` will call the instance of `PlayController#main('abc')`.
If there's no capturing group, the router works just as before: `ListController#main()` is never called with any parameters.